### PR TITLE
Podfile callinvoker fix

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -26,7 +26,7 @@ target 'ReactNativeMasonryListExample' do
   pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
   pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
   pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/jscallinvoker', :path => "../node_modules/react-native/ReactCommon"
+  pod 'ReactCommon/callinvoker', :path => "../node_modules/react-native/ReactCommon"
   pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
   pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
 

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.11.0",
     "react-native": "^0.62.2",
-    "snooper-masonry-list": "^2.16.2"
+    "@snooper/masonry-list": "^3.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",


### PR DESCRIPTION
The patch prevents: 

<img width="1810" alt="Screen Shot 2020-08-14 at 7 17 03 PM" src="https://user-images.githubusercontent.com/2182018/90272076-82752580-de65-11ea-880e-596ae1efd2b9.png">
